### PR TITLE
fix spelling issues

### DIFF
--- a/src/exonpredictor/collectoptimalset.cpp
+++ b/src/exonpredictor/collectoptimalset.cpp
@@ -151,7 +151,7 @@ int findoptimalsetbydp(std::vector<PotentialExon> & potentialExonCandidates, std
         
         // sanity check - all exons refer to the same target
         if (potentialExonCandidates[id].targetLen != targetLength) {
-            Debug(Debug::ERROR) << "two exons are analyzed in the context of differnt targets.\n";
+            Debug(Debug::ERROR) << "two exons are analyzed in the context of different targets.\n";
             EXIT(EXIT_FAILURE);
         }
     }


### PR DESCRIPTION
While packaging metaeuk for Debian, we noticed a number of small spelling mistakes by means of Debian's automated spellcheck tooling for binaries.