### PR TITLE
Update EasyPredict.cpp

### DIFF
--- a/src/workflow/EasyPredict.cpp
+++ b/src/workflow/EasyPredict.cpp
@@ -36,7 +36,7 @@ int easypredict(int argc, const char **argv, const Command& command) {
     cmd.addVariable("VERBOSITY_COMP_PAR", par.createParameterString(par.verbandcompression).c_str());
     cmd.addVariable("THREAD_COMP_PAR", par.createParameterString(par.threadsandcompression).c_str());
 
-    std::string program(tmpDir + "/easypredict.sh");
+    std::string program("/bin/sh " + tmpDir + "/easypredict.sh");
     FileUtil::writeFile(program, easypredict_sh, easypredict_sh_len);
     cmd.execProgram(program.c_str(), par.filenames);
 


### PR DESCRIPTION
Currently easypredict.sh will only run if the file system defaults to giving execute permissions to new files.   
 The simplest solution is to just run teh script as a parameter to /bin/sh.  The script is already dependent on /bin/sh existing via "#!/bin/sh" and so this doesn't create a new dependency.